### PR TITLE
Markup tweaks

### DIFF
--- a/src/docOckHtmlDocumentation.ml
+++ b/src/docOckHtmlDocumentation.ml
@@ -347,7 +347,10 @@ and make_title ~get_package ~lvl ~label txt =
   let header_fun =
     match label with
     | None -> header_fun ~a:attrs
-    | Some (Paths.Identifier.Label (_, lbl)) -> header_fun ~a:(a_id lbl :: attrs)
+    | Some (Paths.Identifier.Label (_, lbl)) ->
+        fun txt ->
+          header_fun ~a:(a_id lbl :: a_class ["anchored"] :: attrs)
+            ((a ~a:[ a_href ("#" ^ lbl); a_class ["anchor"] ] []) :: txt)
   in
   let txt = aggregate ~get_package txt in
   let result, should_error =

--- a/src/docOckHtmlHtml_tree.ml
+++ b/src/docOckHtmlHtml_tree.ml
@@ -238,7 +238,7 @@ class page_creator ?kind ~path content =
         meta ~a:[ a_name "viewport";
                   a_content "width=device-width,initial-scale=1.0"; ] ();
         meta ~a:[ a_name "generator";
-                  a_content "odoc %%VERSION%%" ] ();
+                  a_content "doc-ock-html %%VERSION%%" ] ();
       ]
 
     method heading : Html_types.h1_content_fun elt list =

--- a/src/docOckHtmlHtml_tree.ml
+++ b/src/docOckHtmlHtml_tree.ml
@@ -265,9 +265,10 @@ class page_creator ?kind ~path content =
       else
         nav
           [ a ~a:[ a_href up_href ] [ pcdata "Up" ]
-          ; pcdata " "
-          ; a ~a:[ a_href pkg_href; a_class ["package"] ]
-              [ pcdata "package "; span [ pcdata (List.hd path) ] ]
+          ; pcdata " "; entity "mdash"; pcdata " "
+          ; span ~a:[ a_class ["package"]]
+              [ pcdata "package ";
+                a ~a:[ a_href pkg_href] [ pcdata (List.hd path) ]]
           ]
         :: article
 


### PR DESCRIPTION
A few (I hope) uncontroversial changes. Note that `git grepping` over reveals quite a few markup patterns (e.g. the empty anchor of 22f2213) and constants that would benefit in being abstracted over (also to avoid ocaml-doc/odoc#53). I resisted doing so, I'll let you find your own scheme.